### PR TITLE
feat: Skeleton PWA (Spotify-ready shell)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Skeleton PWA
+
+Minimal static PWA shell prepared for Spotify Web Playback SDK + PKCE (no backend).
+All files live in the repo root for easy static deploy (e.g., Vercel).
+
+## What’s included
+- `index.html` – UI + loads Web Playback SDK
+- `auth.js` – PKCE auth (no secret); uses `location.origin` as redirect URI
+- `player.js` – basic Web Playback SDK wiring
+- `manifest.webmanifest` – optional PWA metadata
+
+## Deploy to Vercel
+1. Import this GitHub repo into Vercel as a new project.
+2. Framework preset: **Other** (static).
+3. Build command: *(leave empty)*.
+4. Output directory: `/` (repo root).
+5. Deploy – you’ll get an HTTPS URL like `https://<project>.vercel.app/`.
+
+## Wire Spotify (user will do this)
+1. Create a Spotify Developer app.
+2. Add **Redirect URI**: your exact Vercel URL with a trailing slash (e.g., `https://<project>.vercel.app/`).
+3. Copy the **Client ID** and paste it into `auth.js` (replace `YOUR_SPOTIFY_CLIENT_ID`).
+4. Redeploy (Vercel auto-deploys on push).
+5. Open your app → **Log in with Spotify** → **Play sample** (must be a user gesture). Requires Spotify Premium.
+
+## Notes
+- Do not store a Client Secret in this repo. PKCE is secretless on the client.
+- If you later use a custom domain, add that exact URL as a Redirect URI in Spotify too.
+- Don’t cache `https://sdk.scdn.co/spotify-player.js` in any service worker.

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,114 @@
+// PKCE auth for a static site (no backend, no secret)
+const SCOPES = [
+  'streaming',
+  'user-read-playback-state',
+  'user-modify-playback-state',
+  'user-read-currently-playing'
+].join(' ');
+
+// 👉 USER ACTION LATER: replace with the real Spotify Client ID after creating the Spotify app
+const CLIENT_ID = 'YOUR_SPOTIFY_CLIENT_ID';
+
+// Redirect URI automatically matches the deployed origin, e.g. https://<project>.vercel.app/
+const REDIRECT_URI = `${location.origin}/`;
+
+// Storage keys
+const K = { access:'sp_access', exp:'sp_exp', refresh:'sp_refresh', verifier:'sp_verifier' };
+const now = () => Math.floor(Date.now() / 1000);
+
+// Helpers
+const b64url = a => btoa(String.fromCharCode(...new Uint8Array(a)))
+  .replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
+const sha256 = async (txt) =>
+  b64url(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(txt)));
+
+export function getAccessTokenSync() {
+  const t = localStorage.getItem(K.access);
+  const e = Number(localStorage.getItem(K.exp) || 0);
+  return t && now() < e - 30 ? t : null;
+}
+
+export async function ensureAuth() {
+  if (!CLIENT_ID || CLIENT_ID.includes('YOUR_SPOTIFY_CLIENT_ID')) {
+    alert('Add your Spotify Client ID in auth.js first.');
+    return;
+  }
+
+  // Handle OAuth redirect
+  const params = new URLSearchParams(location.search);
+  if (params.has('code')) {
+    await handleRedirect(params.get('code'));
+    history.replaceState({}, '', REDIRECT_URI); // clean URL
+  }
+
+  const token = getAccessTokenSync();
+  if (token) return token;
+
+  const refresh = localStorage.getItem(K.refresh);
+  if (refresh) {
+    try { return await refreshToken(refresh); } catch {}
+  }
+
+  // Start login (PKCE)
+  const verifier = b64url(crypto.getRandomValues(new Uint8Array(64)));
+  localStorage.setItem(K.verifier, verifier);
+  const challenge = await sha256(verifier);
+
+  const auth = new URL('https://accounts.spotify.com/authorize');
+  auth.search = new URLSearchParams({
+    client_id: CLIENT_ID,
+    response_type: 'code',
+    redirect_uri: REDIRECT_URI,
+    scope: SCOPES,
+    code_challenge_method: 'S256',
+    code_challenge: challenge,
+    state: b64url(crypto.getRandomValues(new Uint8Array(12)))
+  }).toString();
+  location.assign(auth.toString());
+}
+
+async function handleRedirect(code) {
+  const verifier = localStorage.getItem(K.verifier);
+  if (!verifier) throw new Error('Missing PKCE verifier');
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: REDIRECT_URI,
+    client_id: CLIENT_ID,
+    code_verifier: verifier
+  });
+
+  const res = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: {'Content-Type':'application/x-www-form-urlencoded'},
+    body
+  });
+  if (!res.ok) throw new Error('Token exchange failed');
+  const json = await res.json();
+  storeTokens(json);
+}
+
+async function refreshToken(refresh) {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refresh,
+    client_id: CLIENT_ID
+  });
+  const res = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: {'Content-Type':'application/x-www-form-urlencoded'},
+    body
+  });
+  if (!res.ok) throw new Error('Refresh failed');
+  const json = await res.json();
+  storeTokens(json, true);
+  return localStorage.getItem(K.access);
+}
+
+function storeTokens(json, isRefresh = false) {
+  const { access_token, expires_in, refresh_token } = json;
+  localStorage.setItem(K.access, access_token);
+  localStorage.setItem(K.exp, String(now() + (expires_in || 3600)));
+  if (!isRefresh && refresh_token) localStorage.setItem(K.refresh, refresh_token);
+}

--- a/index.html
+++ b/index.html
@@ -4,10 +4,11 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Skeleton PWA</title>
+    <link rel="manifest" href="manifest.webmanifest" />
   </head>
   <body>
     <main>
-      <h1>My Spotify Player</h1>
+      <h1>Skeleton PWA</h1>
       <p id="status">Deployed? Next step is Spotify auth.</p>
       <button id="login">Log in with Spotify</button>
       <button id="play" disabled>Play sample</button>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,9 @@
+{
+  "name": "Skeleton PWA",
+  "short_name": "Skeleton",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": []
+}

--- a/player.js
+++ b/player.js
@@ -1,0 +1,36 @@
+export async function initPlayer(getTokenSync) {
+  await waitFor(() => window.Spotify && window.Spotify.Player);
+
+  const player = new Spotify.Player({
+    name: 'Skeleton PWA Device',
+    getOAuthToken: cb => cb(getTokenSync())
+  });
+
+  return await new Promise((resolve, reject) => {
+    player.addListener('ready', ({ device_id }) => resolve({ deviceId: device_id, player }));
+    player.addListener('initialization_error', e => reject(e));
+    player.addListener('authentication_error', e => reject(e));
+    player.addListener('account_error', e => reject(e));
+    player.addListener('playback_error', e => reject(e));
+    player.connect();
+  });
+}
+
+export async function startPlayback(deviceId, body) {
+  await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${encodeURIComponent(deviceId)}`, {
+    method: 'PUT',
+    headers: {
+      'Authorization': `Bearer ${localStorage.getItem('sp_access')}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  });
+}
+
+export function pause(player) { player.pause(); }
+
+function waitFor(check, interval = 100) {
+  return new Promise(res => {
+    const t = setInterval(() => { if (check()) { clearInterval(t); res(true); } }, interval);
+  });
+}


### PR DESCRIPTION
## Summary
- add static Skeleton PWA shell prepared for Spotify Web Playback SDK and PKCE placeholders
- include README with deployment and integration guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d127477a08832b89b80eae01a8ce04