### PR TITLE
Improve Spotify playback UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,15 +5,261 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Skeleton PWA</title>
     <link rel="manifest" href="manifest.webmanifest" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #040404;
+        --bg-muted: rgba(255, 255, 255, 0.08);
+        --surface: rgba(9, 9, 9, 0.75);
+        --surface-border: rgba(255, 255, 255, 0.05);
+        --spotify: #1db954;
+        --text: #f7fff7;
+        --text-muted: rgba(247, 255, 247, 0.65);
+        --shadow: rgba(0, 0, 0, 0.45);
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: var(--bg);
+        color: var(--text);
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top, rgba(29, 185, 84, 0.25), transparent 55%),
+          radial-gradient(circle at bottom, rgba(29, 185, 84, 0.15), transparent 45%),
+          var(--bg);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: clamp(1.5rem, 5vw, 3.5rem) 1.5rem;
+        box-sizing: border-box;
+      }
+
+      main {
+        width: min(720px, 100%);
+        background: var(--surface);
+        border: 1px solid var(--surface-border);
+        border-radius: 28px;
+        padding: clamp(1.75rem, 4vw, 2.75rem);
+        box-shadow: 0 28px 65px -35px var(--shadow);
+        backdrop-filter: blur(12px);
+        display: grid;
+        gap: 1.75rem;
+      }
+
+      header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(1.65rem, 4vw, 2.4rem);
+        letter-spacing: -0.03em;
+      }
+
+      #status {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-muted);
+      }
+
+      .controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+      }
+
+      button {
+        appearance: none;
+        border: 0;
+        border-radius: 999px;
+        padding: 0.7rem 1.4rem;
+        font-size: 0.95rem;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+        cursor: pointer;
+        transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+        color: #020202;
+        background: var(--spotify);
+        box-shadow: 0 12px 30px -18px rgba(29, 185, 84, 0.75);
+      }
+
+      button:hover:not(:disabled) {
+        transform: translateY(-1px) scale(1.01);
+        box-shadow: 0 16px 35px -16px rgba(29, 185, 84, 0.9);
+      }
+
+      button:active:not(:disabled) {
+        transform: translateY(0);
+      }
+
+      button:disabled {
+        cursor: not-allowed;
+        opacity: 0.45;
+        background: rgba(255, 255, 255, 0.15);
+        color: rgba(255, 255, 255, 0.35);
+        box-shadow: none;
+      }
+
+      .now-playing {
+        display: grid;
+        grid-template-columns: minmax(0, 180px) 1fr;
+        gap: clamp(1.2rem, 3vw, 2rem);
+        align-items: center;
+        background: linear-gradient(155deg, rgba(29, 185, 84, 0.17), rgba(4, 4, 4, 0.35));
+        border-radius: 24px;
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border: 1px solid rgba(29, 185, 84, 0.2);
+      }
+
+      .album-art {
+        position: relative;
+        width: min(180px, 100%);
+        aspect-ratio: 1 / 1;
+        border-radius: 18px;
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(0, 0, 0, 0.45);
+        box-shadow: 0 22px 40px -30px rgba(0, 0, 0, 0.7);
+        border: 1px solid rgba(29, 185, 84, 0.25);
+      }
+
+      .album-art img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+
+      .album-art__placeholder {
+        font-size: 0.85rem;
+        color: var(--text-muted);
+        text-align: center;
+        padding: 1rem;
+      }
+
+      .now-playing__details {
+        display: grid;
+        gap: 0.85rem;
+        min-width: 0;
+      }
+
+      .track-title {
+        font-size: clamp(1.15rem, 3vw, 1.55rem);
+        font-weight: 700;
+        margin: 0;
+      }
+
+      .track-artists,
+      .track-album {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 0.95rem;
+      }
+
+      .track-meta {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+      }
+
+      .progress {
+        display: grid;
+        gap: 0.5rem;
+      }
+
+      .progress__bar {
+        position: relative;
+        background: rgba(255, 255, 255, 0.12);
+        border-radius: 999px;
+        height: 6px;
+        overflow: hidden;
+      }
+
+      .progress__fill {
+        position: absolute;
+        inset: 0;
+        width: 0;
+        background: linear-gradient(90deg, rgba(29, 185, 84, 1), rgba(29, 185, 84, 0.65));
+      }
+
+      .progress__time {
+        display: flex;
+        justify-content: space-between;
+        font-variant-numeric: tabular-nums;
+        font-size: 0.75rem;
+        color: var(--text-muted);
+      }
+
+      .now-playing__status {
+        font-size: 0.85rem;
+        color: var(--text-muted);
+      }
+
+      @media (max-width: 640px) {
+        .now-playing {
+          grid-template-columns: 1fr;
+        }
+
+        .album-art {
+          width: min(260px, 65vw);
+          justify-self: center;
+        }
+
+        .now-playing__details {
+          text-align: center;
+        }
+
+        .track-meta {
+          align-items: center;
+        }
+
+        .progress__time {
+          font-size: 0.7rem;
+        }
+      }
+    </style>
   </head>
   <body>
     <main>
-      <h1>Skeleton PWA</h1>
-      <p id="status">Deployed? Next step is Spotify auth.</p>
-      <button id="login">Log in with Spotify</button>
-      <button id="play" disabled>Play sample</button>
-      <button id="pause" disabled>Pause</button>
-      <div id="now"></div>
+      <header>
+        <h1>Skeleton PWA</h1>
+        <p id="status">Deployed? Next step is Spotify auth.</p>
+      </header>
+
+      <div class="controls">
+        <button id="login">Log in with Spotify</button>
+        <button id="play" disabled>Play sample</button>
+        <button id="pause" disabled>Pause</button>
+      </div>
+
+      <section class="now-playing" aria-live="polite">
+        <div class="album-art" id="album-art">
+          <div class="album-art__placeholder">Nothing is playing yet</div>
+        </div>
+        <div class="now-playing__details">
+          <div>
+            <p id="track-title" class="track-title">No track playing</p>
+            <div class="track-meta">
+              <p id="track-artist" class="track-artists">—</p>
+              <p id="track-album" class="track-album">—</p>
+            </div>
+          </div>
+          <div class="progress">
+            <div class="progress__bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+              <div class="progress__fill" id="progress-fill"></div>
+            </div>
+            <div class="progress__time">
+              <span id="progress-current">0:00</span>
+              <span id="progress-duration">0:00</span>
+            </div>
+          </div>
+          <p id="now" class="now-playing__status">Waiting for playback…</p>
+        </div>
+      </section>
     </main>
 
     <!-- Spotify Web Playback SDK -->
@@ -27,27 +273,174 @@
       const loginBtn = document.getElementById('login');
       const playBtn = document.getElementById('play');
       const pauseBtn = document.getElementById('pause');
+      const nowStatus = document.getElementById('now');
+      const albumArt = document.getElementById('album-art');
+      const albumPlaceholder = albumArt.querySelector('.album-art__placeholder');
+      const trackTitle = document.getElementById('track-title');
+      const trackArtist = document.getElementById('track-artist');
+      const trackAlbum = document.getElementById('track-album');
+      const progressFill = document.getElementById('progress-fill');
+      const progressCurrent = document.getElementById('progress-current');
+      const progressDuration = document.getElementById('progress-duration');
+      const progressBar = progressFill?.parentElement;
 
-      loginBtn.onclick = async () => { await ensureAuth(); };
+      const progressState = { base: 0, start: 0, duration: 0, paused: true };
+      let progressAnimation = null;
+
+      const formatTime = ms => {
+        if (!Number.isFinite(ms) || ms <= 0) return '0:00';
+        const totalSeconds = Math.max(0, Math.round(ms / 1000));
+        const minutes = Math.floor(totalSeconds / 60);
+        const seconds = String(totalSeconds % 60).padStart(2, '0');
+        return `${minutes}:${seconds}`;
+      };
+
+      const renderProgress = (position, duration) => {
+        const safeDuration = Number.isFinite(duration) && duration > 0 ? duration : 0;
+        const safePosition = Math.min(Math.max(Number(position) || 0, 0), safeDuration || 0);
+        const ratio = safeDuration ? safePosition / safeDuration : 0;
+        if (progressFill) progressFill.style.width = `${ratio * 100}%`;
+        if (progressBar) progressBar.setAttribute('aria-valuenow', String(Math.round(ratio * 100)));
+        if (progressCurrent) progressCurrent.textContent = formatTime(safePosition);
+        if (progressDuration) progressDuration.textContent = formatTime(safeDuration);
+      };
+
+      const cancelProgressAnimation = () => {
+        if (progressAnimation) {
+          cancelAnimationFrame(progressAnimation);
+          progressAnimation = null;
+        }
+      };
+
+      const updateProgressState = state => {
+        progressState.base = Math.max(0, state?.position ?? 0);
+        progressState.start = performance.now();
+        progressState.duration = Math.max(
+          0,
+          state?.track_window?.current_track?.duration_ms ?? state?.duration ?? 0
+        );
+        progressState.paused = Boolean(state?.paused ?? true);
+        if (progressState.base > progressState.duration) {
+          progressState.base = progressState.duration;
+        }
+      };
+
+      const startProgressAnimation = () => {
+        cancelProgressAnimation();
+        if (progressState.paused) {
+          renderProgress(progressState.base, progressState.duration);
+          return;
+        }
+        const step = () => {
+          if (progressState.paused) {
+            cancelProgressAnimation();
+            return;
+          }
+          const elapsed = performance.now() - progressState.start;
+          const position = Math.min(progressState.duration, progressState.base + elapsed);
+          renderProgress(position, progressState.duration);
+          progressAnimation = requestAnimationFrame(step);
+        };
+        progressAnimation = requestAnimationFrame(step);
+      };
+
+      const setAlbumArt = url => {
+        let img = albumArt.querySelector('img');
+        if (url) {
+          if (!img) {
+            img = document.createElement('img');
+            img.alt = 'Album cover';
+            albumArt.appendChild(img);
+          }
+          img.src = url;
+          img.style.display = 'block';
+          if (albumPlaceholder) albumPlaceholder.style.display = 'none';
+        } else {
+          if (img) img.remove();
+          if (albumPlaceholder) albumPlaceholder.style.display = 'block';
+        }
+      };
+
+      const resetNowPlaying = (message = 'Waiting for playback…') => {
+        setAlbumArt(null);
+        trackTitle.textContent = 'No track playing';
+        trackArtist.textContent = '—';
+        trackAlbum.textContent = '—';
+        progressState.base = 0;
+        progressState.start = performance.now();
+        progressState.duration = 0;
+        progressState.paused = true;
+        renderProgress(0, 0);
+        cancelProgressAnimation();
+        nowStatus.textContent = message;
+      };
+
+      const applyPlaybackState = state => {
+        if (!state || !state.track_window?.current_track) {
+          resetNowPlaying('Start a track in Spotify to see it here.');
+          return;
+        }
+
+        const track = state.track_window.current_track;
+        trackTitle.textContent = track?.name || 'Unknown track';
+        trackArtist.textContent = track?.artists?.map(a => a.name).join(', ') || 'Unknown artist';
+        trackAlbum.textContent = track?.album?.name || 'Unknown album';
+        const albumImage = track?.album?.images?.[0]?.url;
+        setAlbumArt(albumImage);
+
+        nowStatus.textContent = state.paused ? 'Paused on this device.' : 'Playing on this device.';
+
+        updateProgressState(state);
+        renderProgress(progressState.base, progressState.duration);
+        startProgressAnimation();
+      };
+
+      resetNowPlaying();
+
+      loginBtn.onclick = async () => {
+        await ensureAuth();
+      };
 
       window.onSpotifyWebPlaybackSDKReady = async () => {
         const token = getAccessTokenSync();
         if (!token) {
           status.textContent = 'Click “Log in with Spotify” first.';
+          resetNowPlaying('Log in to connect to Spotify.');
           return;
         }
         status.textContent = 'Initializing player…';
+        resetNowPlaying('Connecting to your Spotify player…');
 
         const { deviceId, player } = await initPlayer(() => getAccessTokenSync());
         status.textContent = `Device ready: ${deviceId}`;
+        nowStatus.textContent = 'Device ready. Hit play to start listening.';
+
+        player.addListener('player_state_changed', applyPlaybackState);
+
+        try {
+          const initialState = await player.getCurrentState();
+          if (initialState) applyPlaybackState(initialState);
+        } catch (err) {
+          console.warn('Unable to read current playback state', err);
+        }
 
         playBtn.disabled = false;
         pauseBtn.disabled = false;
 
         // Must be triggered by a user gesture
-        playBtn.onclick = () =>
-          startPlayback(deviceId, { uris: ['spotify:track:3n3Ppam7vgaVa1iaRUc9Lp'] }); // example
-        pauseBtn.onclick = () => pause(player);
+        playBtn.onclick = async () => {
+          nowStatus.textContent = 'Requesting playback…';
+          try {
+            await startPlayback(deviceId, { uris: ['spotify:track:3n3Ppam7vgaVa1iaRUc9Lp'] });
+          } catch (err) {
+            console.error(err);
+            nowStatus.textContent = 'Playback request failed.';
+          }
+        };
+        pauseBtn.onclick = () => {
+          pause(player);
+          nowStatus.textContent = 'Paused on this device.';
+        };
       };
     </script>
   </body>


### PR DESCRIPTION
## Summary
- restyle the PWA shell with a dark Spotify-inspired palette and responsive layout
- add a now playing card that surfaces album art, metadata, and playback status
- show real-time song progress updates with a progress bar tied to the Web Playback SDK

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d52e03dfa0832bbf561628d4e91b8c