### PR TITLE
feat: redesign Spotify PWA with vinyl-inspired layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ All files live in the repo root for easy static deploy (e.g., Vercel).
 ## Wire Spotify (user will do this)
 1. Create a Spotify Developer app.
 2. Add **Redirect URI**: your exact Vercel URL with a trailing slash (e.g., `https://<project>.vercel.app/`).
-3. Copy the **Client ID** and paste it into `auth.js` (replace `YOUR_SPOTIFY_CLIENT_ID`).
-4. Redeploy (Vercel auto-deploys on push).
+3. Open your deployed app and use the **Set Client ID** button in the header to paste the value (it is stored locally in your browser and can be changed later).
+4. Redeploy if you changed any source code (Vercel auto-deploys on push).
 5. Open your app → **Log in with Spotify** → **Play sample** (must be a user gesture). Requires Spotify Premium.
 
 ## Notes

--- a/auth.js
+++ b/auth.js
@@ -6,14 +6,67 @@ const SCOPES = [
   'user-read-currently-playing'
 ].join(' ');
 
-// 👉 USER ACTION LATER: replace with the real Spotify Client ID after creating the Spotify app
-const CLIENT_ID = 'YOUR_SPOTIFY_CLIENT_ID';
+const STORAGE_KEY = 'sp_client_id';
+const DEFAULT_CLIENT_ID = 'YOUR_SPOTIFY_CLIENT_ID';
+
+const storage = typeof localStorage !== 'undefined' ? localStorage : null;
+const K = { access:'sp_access', exp:'sp_exp', refresh:'sp_refresh', verifier:'sp_verifier' };
+let clientId = DEFAULT_CLIENT_ID;
+
+const isPlaceholder = value => !value || value.toUpperCase().includes('YOUR_SPOTIFY_CLIENT_ID');
+
+if (storage) {
+  const stored = storage.getItem(STORAGE_KEY);
+  if (stored && stored.trim() && !isPlaceholder(stored.trim())) {
+    clientId = stored.trim();
+  }
+}
+
+const clearStoredTokens = () => {
+  storage?.removeItem(K.access);
+  storage?.removeItem(K.exp);
+  storage?.removeItem(K.refresh);
+};
+
+export function getClientId() {
+  return clientId;
+}
+
+export function hasClientId() {
+  return !isPlaceholder(clientId);
+}
+
+export function configureClientId(nextClientId) {
+  const trimmed = (nextClientId || '').trim();
+  if (!trimmed) {
+    clientId = DEFAULT_CLIENT_ID;
+    storage?.removeItem(STORAGE_KEY);
+    clearStoredTokens();
+    return false;
+  }
+  if (isPlaceholder(trimmed)) {
+    clientId = DEFAULT_CLIENT_ID;
+    storage?.removeItem(STORAGE_KEY);
+    clearStoredTokens();
+    return false;
+  }
+  const changed = clientId !== trimmed;
+  clientId = trimmed;
+  storage?.setItem(STORAGE_KEY, clientId);
+  if (changed) {
+    clearStoredTokens();
+  }
+  return true;
+}
+
+export function clearClientId() {
+  configureClientId('');
+}
 
 // Redirect URI automatically matches the deployed origin, e.g. https://<project>.vercel.app/
 const REDIRECT_URI = `${location.origin}/`;
 
 // Storage keys
-const K = { access:'sp_access', exp:'sp_exp', refresh:'sp_refresh', verifier:'sp_verifier' };
 const now = () => Math.floor(Date.now() / 1000);
 
 // Helpers
@@ -29,10 +82,12 @@ export function getAccessTokenSync() {
 }
 
 export async function ensureAuth() {
-  if (!CLIENT_ID || CLIENT_ID.includes('YOUR_SPOTIFY_CLIENT_ID')) {
-    alert('Add your Spotify Client ID in auth.js first.');
+  if (!hasClientId()) {
+    alert('Set your Spotify Client ID first.');
     return;
   }
+
+  const clientId = getClientId();
 
   // Handle OAuth redirect
   const params = new URLSearchParams(location.search);
@@ -56,7 +111,7 @@ export async function ensureAuth() {
 
   const auth = new URL('https://accounts.spotify.com/authorize');
   auth.search = new URLSearchParams({
-    client_id: CLIENT_ID,
+    client_id: clientId,
     response_type: 'code',
     redirect_uri: REDIRECT_URI,
     scope: SCOPES,
@@ -75,7 +130,7 @@ async function handleRedirect(code) {
     grant_type: 'authorization_code',
     code,
     redirect_uri: REDIRECT_URI,
-    client_id: CLIENT_ID,
+    client_id: clientId,
     code_verifier: verifier
   });
 
@@ -93,7 +148,7 @@ async function refreshToken(refresh) {
   const body = new URLSearchParams({
     grant_type: 'refresh_token',
     refresh_token: refresh,
-    client_id: CLIENT_ID
+    client_id: clientId
   });
   const res = await fetch('https://accounts.spotify.com/api/token', {
     method: 'POST',

--- a/auth.js
+++ b/auth.js
@@ -7,7 +7,7 @@ const SCOPES = [
 ].join(' ');
 
 // 👉 USER ACTION LATER: replace with the real Spotify Client ID after creating the Spotify app
-const CLIENT_ID = '1bc3566e5b8f4ae1bbaafec8950f4c86;
+const CLIENT_ID = 'YOUR_SPOTIFY_CLIENT_ID';
 
 // Redirect URI automatically matches the deployed origin, e.g. https://<project>.vercel.app/
 const REDIRECT_URI = `${location.origin}/`;

--- a/index.html
+++ b/index.html
@@ -656,7 +656,8 @@
         </form>
         <div class="auth-controls">
           <button class="btn-ghost" id="status">Preparing player…</button>
-          <button class="btn-primary" id="login">Log in with Spotify</button>
+          <button class="btn-ghost" id="configureClientId">Set Client ID</button>
+          <button class="btn-primary" id="login" disabled>Log in with Spotify</button>
         </div>
       </header>
 
@@ -770,10 +771,11 @@
     <script src="https://sdk.scdn.co/spotify-player.js"></script>
 
     <script type="module">
-      import { ensureAuth, getAccessTokenSync } from './auth.js';
+      import { ensureAuth, getAccessTokenSync, hasClientId, configureClientId, getClientId } from './auth.js';
       import { initPlayer, startPlayback, pause } from './player.js';
 
       const statusBtn = document.getElementById('status');
+      const configureBtn = document.getElementById('configureClientId');
       const loginBtn = document.getElementById('login');
       const playBtn = document.getElementById('play');
       const pauseBtn = document.getElementById('pause');
@@ -813,11 +815,33 @@
 
       const setStatus = text => {
         statusBtn.textContent = text;
-        statusBtn.ariaLabel = text;
+        statusBtn.setAttribute('aria-label', text);
+      };
+
+      const syncClientIdState = () => {
+        const configured = hasClientId();
+        loginBtn.disabled = !configured;
+        loginBtn.textContent = configured ? 'Log in with Spotify' : 'Set Client ID first';
+        configureBtn.textContent = configured ? 'Update Client ID' : 'Set Client ID';
+        configureBtn.setAttribute('aria-label', configured ? 'Update Spotify Client ID' : 'Set Spotify Client ID');
+        configureBtn.dataset.configured = configured ? 'true' : 'false';
+        if (!configured && !getAccessTokenSync()) {
+          setStatus('Add your Spotify Client ID to begin');
+        }
       };
 
       const withToken = async cb => {
-        const token = getAccessTokenSync();
+        let token = getAccessTokenSync();
+        let hasRefresh = false;
+        try {
+          hasRefresh = !!localStorage.getItem('sp_refresh');
+        } catch (err) {
+          console.warn('Local storage unavailable', err);
+        }
+        if (!token && hasRefresh) {
+          await ensureAuth();
+          token = getAccessTokenSync();
+        }
         if (!token) {
           setStatus('Please log in first');
           return null;
@@ -1192,10 +1216,29 @@
 
       hideSearchResults();
 
+      syncClientIdState();
+
+      configureBtn.addEventListener('click', () => {
+        const existing = hasClientId() ? getClientId() : '';
+        const entered = prompt('Enter your Spotify Client ID', existing);
+        if (entered === null) return;
+        const saved = configureClientId(entered);
+        if (!saved) {
+          setStatus('Client ID cleared. Enter it to continue.');
+        } else {
+          setStatus('Client ID saved locally. Ready to log in.');
+        }
+        syncClientIdState();
+      });
+
       playlistToggle.addEventListener('click', () => toggleDrawer(playlistDrawer.hasAttribute('hidden')));
       closeDrawer.addEventListener('click', () => toggleDrawer(false));
 
       loginBtn.onclick = async () => {
+        if (!hasClientId()) {
+          configureBtn.click();
+          return;
+        }
         await ensureAuth();
         setStatus('Authenticated. Initializing…');
       };

--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
         justify-content: space-between;
         align-items: center;
         gap: 1rem;
+        flex-wrap: wrap;
       }
 
       .brand {
@@ -82,6 +83,49 @@
       .auth-controls {
         display: flex;
         gap: 0.75rem;
+      }
+
+      .search {
+        flex: 1 1 320px;
+        max-width: 520px;
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        background: rgba(255, 255, 255, 0.06);
+        border-radius: 999px;
+        padding: 0.4rem 0.6rem 0.4rem 0.9rem;
+        box-shadow: 0 12px 34px rgba(0, 0, 0, 0.28);
+        backdrop-filter: blur(14px);
+      }
+
+      .search svg {
+        width: 1.1rem;
+        height: 1.1rem;
+        opacity: 0.7;
+      }
+
+      .search input {
+        flex: 1;
+        background: transparent;
+        border: none;
+        color: inherit;
+        font-size: 0.95rem;
+        font-family: inherit;
+        outline: none;
+      }
+
+      .search input::placeholder {
+        color: rgba(247, 247, 247, 0.55);
+      }
+
+      .search:focus-within {
+        background: rgba(255, 255, 255, 0.1);
+        box-shadow: 0 12px 34px rgba(30, 215, 96, 0.22);
+      }
+
+      .search__submit {
+        padding-inline: 1rem;
+        white-space: nowrap;
       }
 
       button {
@@ -327,6 +371,76 @@
         font-size: 1.05rem;
       }
 
+      .search-results {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        background: rgba(0, 0, 0, 0.22);
+        border-radius: 1.25rem;
+        padding: 1rem 1.2rem;
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+      }
+
+      .search-results__status {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .search-results__list {
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .search-result {
+        background: rgba(255, 255, 255, 0.08);
+        border-radius: 1rem;
+        padding: 0.75rem 1rem;
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        gap: 0.9rem;
+        text-align: left;
+        border: none;
+        color: inherit;
+        cursor: pointer;
+        transition: transform 160ms ease, background 160ms ease;
+      }
+
+      .search-result:hover {
+        transform: translateY(-1px);
+        background: rgba(30, 215, 96, 0.18);
+      }
+
+      .search-result__thumb {
+        width: 48px;
+        height: 48px;
+        border-radius: 12px;
+        display: block;
+        object-fit: cover;
+        box-shadow: 0 12px 20px rgba(0, 0, 0, 0.35);
+      }
+
+      .search-result__meta {
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+      }
+
+      .search-result__meta strong {
+        font-size: 0.95rem;
+      }
+
+      .search-result__meta span {
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+      }
+
+      .search-result__duration {
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+      }
+
       .volume-control {
         display: flex;
         align-items: center;
@@ -499,6 +613,25 @@
           padding: 1.5rem;
         }
 
+        header {
+          justify-content: center;
+          gap: 1.25rem;
+        }
+
+        .auth-controls {
+          width: 100%;
+          justify-content: flex-end;
+        }
+
+        .search {
+          flex-basis: 100%;
+          max-width: none;
+        }
+
+        .search__submit {
+          padding-inline: 0.9rem;
+        }
+
         .controls {
           grid-template-columns: repeat(3, minmax(0, 1fr));
         }
@@ -513,6 +646,14 @@
     <main>
       <header>
         <div class="brand">Midnight Vinyl Remote</div>
+        <form class="search" id="searchForm" role="search" aria-label="Search Spotify tracks">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="11" cy="11" r="7"></circle>
+            <line x1="20" y1="20" x2="16.65" y2="16.65"></line>
+          </svg>
+          <input id="searchInput" type="search" placeholder="Search tracks or artists" aria-label="Search tracks or artists" />
+          <button class="btn-primary search__submit" type="submit">Search</button>
+        </form>
         <div class="auth-controls">
           <button class="btn-ghost" id="status">Preparing player…</button>
           <button class="btn-primary" id="login">Log in with Spotify</button>
@@ -543,6 +684,11 @@
             <span id="elapsed">0:00</span>
             <span id="remaining">0:00</span>
           </div>
+
+          <section class="search-results" id="searchResults" hidden>
+            <p class="search-results__status" id="searchStatus" aria-live="polite">Search for tracks to jump right in.</p>
+            <div class="search-results__list" id="searchItems"></div>
+          </section>
 
           <div class="controls" role="group" aria-label="Playback controls">
             <button class="btn-ghost" id="shuffle" aria-pressed="false" title="Toggle shuffle">
@@ -651,6 +797,11 @@
       const trackList = document.getElementById('trackList');
       const trackItems = document.getElementById('trackItems');
       const trackListTitle = document.getElementById('trackListTitle');
+      const searchForm = document.getElementById('searchForm');
+      const searchInput = document.getElementById('searchInput');
+      const searchResults = document.getElementById('searchResults');
+      const searchStatus = document.getElementById('searchStatus');
+      const searchItems = document.getElementById('searchItems');
 
       let deviceId = null;
       let playerInstance = null;
@@ -658,6 +809,7 @@
       let progressMs = 0;
       let durationMs = 0;
       let isPlaying = false;
+      let searchRequestId = 0;
 
       const setStatus = text => {
         statusBtn.textContent = text;
@@ -879,23 +1031,41 @@
         }
       };
 
-      const playSelectedTrack = async (track, playlist) => {
+      const triggerPlayback = async (body, trackName) => {
         if (!deviceId) {
           setStatus('Player not ready yet');
-          return;
+          return false;
         }
         try {
-          await startPlayback(deviceId, {
-            context_uri: playlist.uri,
-            offset: { uri: track.uri }
-          });
-          setStatus(`Playing ${track.name}`);
+          await startPlayback(deviceId, body);
+          if (trackName) {
+            setStatus(`Playing ${trackName}`);
+          }
           await refreshNowPlaying();
+          return true;
         } catch (err) {
           console.error(err);
           setStatus('Unable to start track');
+          return false;
         }
       };
+
+      const playSelectedTrack = async (track, playlist) =>
+        triggerPlayback(
+          {
+            context_uri: playlist.uri,
+            offset: { uri: track.uri }
+          },
+          track.name
+        );
+
+      const playSearchResult = track =>
+        triggerPlayback(
+          {
+            uris: [track.uri]
+          },
+          track.name
+        );
 
       const toggleDrawer = show => {
         if (show) {
@@ -905,6 +1075,122 @@
         }
         playlistToggle.setAttribute('aria-expanded', show.toString());
       };
+
+      const ensureSearchVisible = () => {
+        if (searchResults) {
+          searchResults.hidden = false;
+        }
+      };
+
+      const hideSearchResults = () => {
+        if (searchResults) {
+          searchResults.hidden = true;
+        }
+        if (searchStatus) {
+          searchStatus.textContent = 'Search for tracks to jump right in.';
+        }
+        if (searchItems) {
+          searchItems.innerHTML = '';
+        }
+      };
+
+      const updateSearchStatus = message => {
+        ensureSearchVisible();
+        if (searchStatus) {
+          searchStatus.textContent = message;
+        }
+      };
+
+      const renderSearchTracks = tracks => {
+        if (!searchItems) return;
+        searchItems.innerHTML = '';
+        tracks.forEach(track => {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = 'search-result';
+
+          const imageUrl = track.album?.images?.[2]?.url || track.album?.images?.[1]?.url || track.album?.images?.[0]?.url;
+          if (imageUrl) {
+            const img = document.createElement('img');
+            img.className = 'search-result__thumb';
+            img.src = imageUrl;
+            img.alt = track.album?.name ? `${track.album.name} cover` : 'Album artwork';
+            button.appendChild(img);
+          } else {
+            const placeholder = document.createElement('div');
+            placeholder.className = 'search-result__thumb';
+            placeholder.setAttribute('aria-hidden', 'true');
+            placeholder.style.background = 'rgba(255, 255, 255, 0.08)';
+            button.appendChild(placeholder);
+          }
+
+          const meta = document.createElement('div');
+          meta.className = 'search-result__meta';
+
+          const nameEl = document.createElement('strong');
+          nameEl.textContent = track.name;
+          meta.appendChild(nameEl);
+
+          const artistsEl = document.createElement('span');
+          artistsEl.textContent = track.artists?.map(a => a.name).join(', ') || 'Unknown artist';
+          meta.appendChild(artistsEl);
+          button.appendChild(meta);
+
+          const durationEl = document.createElement('span');
+          durationEl.className = 'search-result__duration';
+          durationEl.textContent = track.duration_ms ? msToTime(track.duration_ms) : '';
+          button.appendChild(durationEl);
+
+          button.addEventListener('click', () => playSearchResult(track));
+          searchItems.appendChild(button);
+        });
+      };
+
+      if (searchInput) {
+        searchInput.addEventListener('input', () => {
+          if (!searchInput.value.trim()) {
+            hideSearchResults();
+          }
+        });
+      }
+
+      if (searchForm) {
+        searchForm.addEventListener('submit', async event => {
+          event.preventDefault();
+          if (!searchInput) return;
+          const query = searchInput.value.trim();
+          if (!query) {
+            hideSearchResults();
+            return;
+          }
+          const requestId = ++searchRequestId;
+          updateSearchStatus('Searching…');
+          if (searchItems) {
+            searchItems.innerHTML = '';
+          }
+          try {
+            const data = await apiRequest(`search?type=track&limit=6&q=${encodeURIComponent(query)}`);
+            if (requestId !== searchRequestId) return;
+            if (!data) {
+              updateSearchStatus('Log in to search Spotify.');
+              return;
+            }
+            const tracks = data.tracks?.items || [];
+            if (!tracks.length) {
+              updateSearchStatus(`No tracks found for "${query}".`);
+              return;
+            }
+            updateSearchStatus(`Results for "${query}"`);
+            renderSearchTracks(tracks);
+          } catch (err) {
+            console.error(err);
+            if (requestId !== searchRequestId) return;
+            updateSearchStatus('Unable to search right now.');
+          }
+        });
+      }
+
+      hideSearchResults();
 
       playlistToggle.addEventListener('click', () => toggleDrawer(playlistDrawer.hasAttribute('hidden')));
       closeDrawer.addEventListener('click', () => toggleDrawer(false));

--- a/index.html
+++ b/index.html
@@ -1,54 +1,1055 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Skeleton PWA</title>
+    <title>Skeleton PWA – Vinyl Control Room</title>
     <link rel="manifest" href="manifest.webmanifest" />
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap');
+
+      :root {
+        color-scheme: dark;
+        --bg-gradient-start: #0f2922;
+        --bg-gradient-end: #1a0f2d;
+        --accent: #1ed760;
+        --accent-muted: rgba(30, 215, 96, 0.35);
+        --card-bg: rgba(18, 18, 18, 0.55);
+        --text-primary: #f7f7f7;
+        --text-secondary: rgba(247, 247, 247, 0.7);
+        --vinyl-progress: 0turn;
+        --tonearm-rotation: -28deg;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        font-family: 'Plus Jakarta Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: radial-gradient(circle at top left, rgba(30, 215, 96, 0.15), transparent 40%),
+          radial-gradient(circle at bottom right, rgba(102, 51, 153, 0.25), transparent 45%),
+          linear-gradient(145deg, var(--bg-gradient-start), var(--bg-gradient-end));
+        background-size: 140% 140%;
+        animation: aurora 16s ease-in-out infinite alternate;
+        color: var(--text-primary);
+      }
+
+      @keyframes aurora {
+        0% {
+          background-position: 0% 30%, 70% 100%, 0% 0%;
+        }
+        100% {
+          background-position: 40% 0%, 100% 60%, 100% 100%;
+        }
+      }
+
+      body::before {
+        content: '';
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        background: linear-gradient(120deg, rgba(255, 255, 255, 0.06), transparent 60%);
+        mix-blend-mode: screen;
+        opacity: 0.7;
+      }
+
+      main {
+        min-height: 100%;
+        display: flex;
+        flex-direction: column;
+        padding: clamp(1.5rem, 4vw, 3rem);
+        gap: clamp(1.5rem, 4vw, 3rem);
+      }
+
+      header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .brand {
+        font-size: clamp(1.2rem, 2.5vw, 1.6rem);
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+        color: var(--text-secondary);
+      }
+
+      .auth-controls {
+        display: flex;
+        gap: 0.75rem;
+      }
+
+      button {
+        border: none;
+        border-radius: 999px;
+        padding: 0.75rem 1.5rem;
+        font-weight: 600;
+        font-size: 0.95rem;
+        letter-spacing: 0.02em;
+        cursor: pointer;
+        transition: transform 160ms ease, box-shadow 160ms ease, background 200ms ease;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.6rem;
+        color: var(--text-primary);
+      }
+
+      button:disabled {
+        cursor: not-allowed;
+        opacity: 0.45;
+      }
+
+      .btn-primary {
+        background: linear-gradient(135deg, rgba(30, 215, 96, 0.9), rgba(30, 215, 96, 0.6));
+        box-shadow: 0 12px 30px rgba(30, 215, 96, 0.25);
+      }
+
+      .btn-primary:hover:not(:disabled) {
+        transform: translateY(-2px);
+        box-shadow: 0 18px 36px rgba(30, 215, 96, 0.35);
+      }
+
+      .btn-ghost {
+        background: rgba(255, 255, 255, 0.08);
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      }
+
+      .btn-ghost:hover:not(:disabled) {
+        background: rgba(255, 255, 255, 0.12);
+        transform: translateY(-2px);
+      }
+
+      .layout {
+        flex: 1;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: clamp(2rem, 5vw, 3.5rem);
+        align-items: center;
+      }
+
+      .vinyl-stage {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: clamp(1.5rem, 4vw, 4rem);
+        background: rgba(0, 0, 0, 0.18);
+        border-radius: clamp(1.5rem, 4vw, 3rem);
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05), 0 30px 60px rgba(0, 0, 0, 0.35);
+        overflow: hidden;
+      }
+
+      .vinyl-wrapper {
+        position: relative;
+        width: min(420px, 70vw);
+        aspect-ratio: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        filter: drop-shadow(0 30px 60px rgba(0, 0, 0, 0.55));
+      }
+
+      .vinyl-progress-ring {
+        position: absolute;
+        inset: -10%;
+        border-radius: 50%;
+        background: conic-gradient(var(--accent) var(--vinyl-progress), rgba(255, 255, 255, 0.06) var(--vinyl-progress));
+        filter: blur(0.4px);
+        opacity: 0.85;
+        transition: background 300ms ease;
+      }
+
+      .vinyl {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        border-radius: 50%;
+        background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.05), transparent 55%),
+          repeating-radial-gradient(circle, #050505 0 2px, #111 2px 4px);
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        box-shadow: inset 0 -15px 25px rgba(0, 0, 0, 0.6), inset 0 20px 30px rgba(255, 255, 255, 0.05);
+        transform-origin: center;
+        transition: filter 260ms ease;
+      }
+
+      .vinyl::before {
+        content: '';
+        position: absolute;
+        inset: 12%;
+        border-radius: 50%;
+        background: radial-gradient(circle at 70% 30%, rgba(255, 255, 255, 0.08), rgba(0, 0, 0, 0.85));
+        mix-blend-mode: screen;
+        opacity: 0.35;
+        pointer-events: none;
+      }
+
+      .vinyl__label {
+        position: relative;
+        width: 42%;
+        aspect-ratio: 1;
+        border-radius: 50%;
+        overflow: hidden;
+        display: grid;
+        place-items: center;
+        border: 6px solid rgba(0, 0, 0, 0.65);
+        box-shadow: inset 0 0 0 3px rgba(255, 255, 255, 0.06);
+        background: radial-gradient(circle at 40% 40%, rgba(255, 255, 255, 0.15), rgba(0, 0, 0, 0.55));
+      }
+
+      .vinyl__label img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        filter: saturate(1.1) contrast(1.05);
+      }
+
+      .vinyl__spindle {
+        position: absolute;
+        width: 4.5%;
+        height: 4.5%;
+        border-radius: 50%;
+        background: radial-gradient(circle, rgba(255, 255, 255, 0.85), rgba(200, 200, 200, 0.25));
+        z-index: 3;
+      }
+
+      .tonearm {
+        position: absolute;
+        width: 48%;
+        height: 48%;
+        top: 10%;
+        right: 2%;
+        transform-origin: top left;
+        transform: rotate(var(--tonearm-rotation));
+        transition: transform 400ms ease;
+        pointer-events: none;
+      }
+
+      .tonearm::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 12px;
+        height: 65%;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.75), rgba(30, 30, 30, 0.9));
+        border-radius: 999px;
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+      }
+
+      .tonearm::after {
+        content: '';
+        position: absolute;
+        bottom: -6%;
+        left: 2px;
+        width: 26px;
+        height: 18%;
+        background: linear-gradient(130deg, rgba(0, 0, 0, 0.8), rgba(80, 80, 80, 0.9));
+        border-radius: 4px 4px 10px 10px;
+        transform: rotate(6deg);
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+      }
+
+      .vinyl.spinning {
+        animation: spin 6s linear infinite;
+      }
+
+      @keyframes spin {
+        from {
+          transform: rotate(0deg);
+        }
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      .info-panel {
+        display: flex;
+        flex-direction: column;
+        gap: clamp(1.5rem, 3vw, 2.5rem);
+        padding: clamp(1.5rem, 4vw, 2.75rem);
+        background: var(--card-bg);
+        border-radius: clamp(1.5rem, 4vw, 3rem);
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06), 0 24px 60px rgba(0, 0, 0, 0.45);
+        backdrop-filter: blur(16px);
+      }
+
+      .status {
+        color: var(--text-secondary);
+        font-size: 0.95rem;
+        letter-spacing: 0.01em;
+      }
+
+      .track-meta h1 {
+        font-size: clamp(1.6rem, 3vw, 2.4rem);
+        margin: 0;
+      }
+
+      .track-meta p {
+        margin: 0.35rem 0 0;
+        color: var(--text-secondary);
+      }
+
+      .controls {
+        display: grid;
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        gap: 0.85rem;
+        align-items: center;
+      }
+
+      .controls button {
+        padding: 0.85rem;
+        justify-content: center;
+      }
+
+      .controls button svg {
+        width: 20px;
+        height: 20px;
+      }
+
+      .primary-controls {
+        grid-column: span 5;
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        margin-top: 0.5rem;
+      }
+
+      .primary-controls button {
+        padding: 1rem 1.35rem;
+        font-size: 1.05rem;
+      }
+
+      .volume-control {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        margin-top: 1rem;
+      }
+
+      .volume-control input[type='range'] {
+        flex: 1;
+        -webkit-appearance: none;
+        appearance: none;
+        height: 4px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.15);
+        outline: none;
+      }
+
+      .volume-control input[type='range']::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: var(--accent);
+        box-shadow: 0 0 0 6px rgba(30, 215, 96, 0.2);
+        cursor: pointer;
+      }
+
+      .volume-control input[type='range']::-moz-range-thumb {
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: var(--accent);
+        box-shadow: 0 0 0 6px rgba(30, 215, 96, 0.2);
+        border: none;
+        cursor: pointer;
+      }
+
+      .progress-time {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .playlist-toggle {
+        margin-top: auto;
+        align-self: flex-end;
+      }
+
+      .playlist-drawer {
+        position: relative;
+        background: rgba(0, 0, 0, 0.32);
+        border-radius: clamp(1.5rem, 4vw, 3rem);
+        padding: clamp(1.5rem, 4vw, 2.5rem);
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05), 0 -18px 42px rgba(0, 0, 0, 0.35);
+        backdrop-filter: blur(22px);
+      }
+
+      .drawer-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1.5rem;
+      }
+
+      .drawer-header h2 {
+        margin: 0;
+        font-size: 1.2rem;
+        letter-spacing: 0.04em;
+      }
+
+      .drawer-header .subtitle {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-top: 0.25rem;
+      }
+
+      .playlist-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 1.25rem;
+      }
+
+      .playlist-card {
+        background: rgba(255, 255, 255, 0.06);
+        border-radius: 1.2rem;
+        padding: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        cursor: pointer;
+        transition: transform 180ms ease, box-shadow 180ms ease, background 220ms ease;
+      }
+
+      .playlist-card:hover {
+        transform: translateY(-6px);
+        box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+        background: rgba(255, 255, 255, 0.12);
+      }
+
+      .playlist-card img {
+        width: 100%;
+        aspect-ratio: 1;
+        border-radius: 0.9rem;
+        object-fit: cover;
+      }
+
+      .playlist-card h3 {
+        margin: 0;
+        font-size: 1rem;
+      }
+
+      .playlist-card p {
+        margin: 0;
+        color: var(--text-secondary);
+        font-size: 0.8rem;
+      }
+
+      .tracklist {
+        margin-top: 2rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.08);
+        display: grid;
+        gap: 1rem;
+      }
+
+      .track-item {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        gap: 1rem;
+        align-items: center;
+        padding: 0.75rem 1rem;
+        border-radius: 0.9rem;
+        background: rgba(255, 255, 255, 0.04);
+        transition: background 200ms ease, transform 200ms ease;
+        cursor: pointer;
+      }
+
+      .track-item:hover {
+        background: rgba(255, 255, 255, 0.1);
+        transform: translateY(-2px);
+      }
+
+      .track-item span {
+        color: var(--text-secondary);
+        font-size: 0.8rem;
+      }
+
+      .track-item strong {
+        font-weight: 600;
+      }
+
+      @media (max-width: 1024px) {
+        .layout {
+          grid-template-columns: 1fr;
+        }
+
+        .vinyl-stage {
+          order: -1;
+        }
+
+        .info-panel {
+          order: 0;
+        }
+      }
+
+      @media (max-width: 720px) {
+        main {
+          padding: 1.5rem;
+        }
+
+        .controls {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+
+        .primary-controls {
+          flex-wrap: wrap;
+        }
+      }
+    </style>
   </head>
   <body>
     <main>
-      <h1>Skeleton PWA</h1>
-      <p id="status">Deployed? Next step is Spotify auth.</p>
-      <button id="login">Log in with Spotify</button>
-      <button id="play" disabled>Play sample</button>
-      <button id="pause" disabled>Pause</button>
-      <div id="now"></div>
+      <header>
+        <div class="brand">Midnight Vinyl Remote</div>
+        <div class="auth-controls">
+          <button class="btn-ghost" id="status">Preparing player…</button>
+          <button class="btn-primary" id="login">Log in with Spotify</button>
+        </div>
+      </header>
+
+      <section class="layout" aria-label="Vinyl playback experience">
+        <div class="vinyl-stage">
+          <div class="vinyl-wrapper">
+            <div class="vinyl-progress-ring" aria-hidden="true"></div>
+            <div class="vinyl" id="vinyl" aria-hidden="true">
+              <div class="vinyl__label">
+                <img id="albumArt" src="https://i.scdn.co/image/ab67616d0000b273b6f76f1a9c82335cf0bf8d6b" alt="Album artwork" />
+              </div>
+              <div class="vinyl__spindle"></div>
+            </div>
+            <div class="tonearm"></div>
+          </div>
+        </div>
+
+        <section class="info-panel" aria-label="Playback controls and information">
+          <div class="track-meta">
+            <h1 id="trackTitle">Nothing playing yet</h1>
+            <p id="trackSubtitle">Authenticate to take over your Spotify playback.</p>
+          </div>
+
+          <div class="progress-time" aria-live="polite">
+            <span id="elapsed">0:00</span>
+            <span id="remaining">0:00</span>
+          </div>
+
+          <div class="controls" role="group" aria-label="Playback controls">
+            <button class="btn-ghost" id="shuffle" aria-pressed="false" title="Toggle shuffle">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="16 3 21 3 21 8"></polyline>
+                <line x1="4" y1="20" x2="21" y2="3"></line>
+                <polyline points="21 16 21 21 16 21"></polyline>
+                <line x1="15" y1="15" x2="21" y2="21"></line>
+                <line x1="4" y1="4" x2="9" y2="9"></line>
+              </svg>
+            </button>
+            <button class="btn-ghost" id="previous" title="Previous track">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <polygon points="19 20 9 12 19 4 19 20"></polygon>
+                <line x1="5" y1="19" x2="5" y2="5"></line>
+              </svg>
+            </button>
+            <div class="primary-controls">
+              <button class="btn-ghost" id="play" disabled>
+                <svg viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M6 4l12 8-12 8z" />
+                </svg>
+                Play
+              </button>
+              <button class="btn-ghost" id="pause" disabled>
+                <svg viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M7 4h4v16H7zM13 4h4v16h-4z" />
+                </svg>
+                Pause
+              </button>
+              <button class="btn-ghost" id="resume" hidden>
+                <svg viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+                Resume
+              </button>
+            </div>
+            <button class="btn-ghost" id="next" title="Next track">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <polygon points="5 4 15 12 5 20 5 4"></polygon>
+                <line x1="19" y1="5" x2="19" y2="19"></line>
+              </svg>
+            </button>
+            <button class="btn-ghost" id="repeat" aria-pressed="false" title="Toggle repeat">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="17 1 21 5 17 9"></polyline>
+                <path d="M3 11V9a4 4 0 0 1 4-4h14"></path>
+                <polyline points="7 23 3 19 7 15"></polyline>
+                <path d="M21 13v2a4 4 0 0 1-4 4H3"></path>
+              </svg>
+            </button>
+          </div>
+
+          <div class="volume-control">
+            <span style="color: var(--text-secondary); font-size: 0.85rem;">Volume</span>
+            <input type="range" id="volume" min="0" max="100" value="60" disabled />
+          </div>
+
+          <button class="btn-primary playlist-toggle" id="playlistToggle" aria-expanded="false">Browse playlists</button>
+        </section>
+      </section>
+
+      <section class="playlist-drawer" id="playlistDrawer" hidden>
+        <div class="drawer-header">
+          <div>
+            <h2>Playlists</h2>
+            <div class="subtitle" id="playlistSubtitle">Sign in to pull your Spotify collections.</div>
+          </div>
+          <button class="btn-ghost" id="closeDrawer">Close</button>
+        </div>
+        <div class="playlist-grid" id="playlistGrid" aria-live="polite"></div>
+        <div class="tracklist" id="trackList" hidden>
+          <h3 id="trackListTitle" style="margin: 0; font-size: 1.05rem;">Tracks</h3>
+          <div id="trackItems"></div>
+        </div>
+      </section>
     </main>
 
-    <!-- Spotify Web Playback SDK -->
     <script src="https://sdk.scdn.co/spotify-player.js"></script>
 
     <script type="module">
       import { ensureAuth, getAccessTokenSync } from './auth.js';
       import { initPlayer, startPlayback, pause } from './player.js';
 
-      const status = document.getElementById('status');
+      const statusBtn = document.getElementById('status');
       const loginBtn = document.getElementById('login');
       const playBtn = document.getElementById('play');
       const pauseBtn = document.getElementById('pause');
+      const resumeBtn = document.getElementById('resume');
+      const shuffleBtn = document.getElementById('shuffle');
+      const repeatBtn = document.getElementById('repeat');
+      const prevBtn = document.getElementById('previous');
+      const nextBtn = document.getElementById('next');
+      const volumeRange = document.getElementById('volume');
+      const vinyl = document.getElementById('vinyl');
+      const albumArt = document.getElementById('albumArt');
+      const elapsedEl = document.getElementById('elapsed');
+      const remainingEl = document.getElementById('remaining');
+      const trackTitle = document.getElementById('trackTitle');
+      const trackSubtitle = document.getElementById('trackSubtitle');
+      const playlistToggle = document.getElementById('playlistToggle');
+      const playlistDrawer = document.getElementById('playlistDrawer');
+      const closeDrawer = document.getElementById('closeDrawer');
+      const playlistGrid = document.getElementById('playlistGrid');
+      const playlistSubtitle = document.getElementById('playlistSubtitle');
+      const trackList = document.getElementById('trackList');
+      const trackItems = document.getElementById('trackItems');
+      const trackListTitle = document.getElementById('trackListTitle');
 
-      loginBtn.onclick = async () => { await ensureAuth(); };
+      let deviceId = null;
+      let playerInstance = null;
+      let progressTimer = null;
+      let progressMs = 0;
+      let durationMs = 0;
+      let isPlaying = false;
+
+      const setStatus = text => {
+        statusBtn.textContent = text;
+        statusBtn.ariaLabel = text;
+      };
+
+      const withToken = async cb => {
+        const token = getAccessTokenSync();
+        if (!token) {
+          setStatus('Please log in first');
+          return null;
+        }
+        return cb(token);
+      };
+
+      const apiRequest = async (endpoint, { method = 'GET', body = undefined } = {}) =>
+        withToken(async token => {
+          const res = await fetch(`https://api.spotify.com/v1/${endpoint}`, {
+            method,
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json'
+            },
+            body: body ? JSON.stringify(body) : undefined
+          });
+          if (res.status === 204) {
+            return null;
+          }
+          if (!res.ok) {
+            const message = await res.text();
+            console.error('Spotify API error', res.status, message);
+            throw new Error(message || 'Spotify API error');
+          }
+          return res.json();
+        });
+
+      const msToTime = ms => {
+        if (!ms && ms !== 0) return '0:00';
+        const totalSeconds = Math.floor(ms / 1000);
+        const minutes = Math.floor(totalSeconds / 60);
+        const seconds = `${totalSeconds % 60}`.padStart(2, '0');
+        return `${minutes}:${seconds}`;
+      };
+
+      const updateProgressUi = () => {
+        if (!durationMs) return;
+        const progress = Math.min(progressMs / durationMs, 1);
+        document.documentElement.style.setProperty('--vinyl-progress', `${progress}turn`);
+        const tonearmRotation = -28 + progress * 48;
+        document.documentElement.style.setProperty('--tonearm-rotation', `${tonearmRotation}deg`);
+        elapsedEl.textContent = msToTime(progressMs);
+        remainingEl.textContent = msToTime(Math.max(durationMs - progressMs, 0));
+      };
+
+      const startProgressTimer = () => {
+        clearInterval(progressTimer);
+        progressTimer = setInterval(() => {
+          if (!isPlaying) return;
+          progressMs = Math.min(progressMs + 1000, durationMs);
+          updateProgressUi();
+        }, 1000);
+      };
+
+      const stopProgressTimer = () => {
+        clearInterval(progressTimer);
+        progressTimer = null;
+      };
+
+      const setPlayingState = playing => {
+        isPlaying = playing;
+        vinyl.classList.toggle('spinning', playing);
+        resumeBtn.hidden = true;
+        playBtn.disabled = playing;
+        pauseBtn.disabled = !playing;
+        if (!playing) {
+          document.documentElement.style.setProperty('--tonearm-rotation', '-20deg');
+        }
+      };
+
+      const setAlbumArt = async url => {
+        albumArt.src = url;
+        try {
+          const dominant = await extractAverageColor(url);
+          if (dominant) {
+            const [r, g, b] = dominant;
+            const accent = `rgb(${r}, ${g}, ${b})`;
+            document.documentElement.style.setProperty('--accent', accent);
+            document.documentElement.style.setProperty('--accent-muted', `rgba(${r}, ${g}, ${b}, 0.35)`);
+          }
+        } catch (err) {
+          console.warn('Album color extraction failed', err);
+        }
+      };
+
+      const extractAverageColor = url =>
+        new Promise((resolve, reject) => {
+          const img = new Image();
+          img.crossOrigin = 'anonymous';
+          img.src = url;
+          img.onload = () => {
+            try {
+              const canvas = document.createElement('canvas');
+              const size = 40;
+              canvas.width = size;
+              canvas.height = size;
+              const ctx = canvas.getContext('2d');
+              ctx.drawImage(img, 0, 0, size, size);
+              const data = ctx.getImageData(0, 0, size, size).data;
+              let r = 0,
+                g = 0,
+                b = 0;
+              const length = data.length / 4;
+              for (let i = 0; i < data.length; i += 4) {
+                r += data[i];
+                g += data[i + 1];
+                b += data[i + 2];
+              }
+              resolve([Math.round(r / length), Math.round(g / length), Math.round(b / length)]);
+            } catch (error) {
+              reject(error);
+            }
+          };
+          img.onerror = reject;
+        });
+
+      const refreshNowPlaying = async () => {
+        try {
+          const playback = await apiRequest('me/player/currently-playing');
+          if (!playback || !playback.item) {
+            trackTitle.textContent = 'No track playing';
+            trackSubtitle.textContent = 'Pick something from your playlists to get started.';
+            setPlayingState(false);
+            progressMs = 0;
+            durationMs = 0;
+            updateProgressUi();
+            return;
+          }
+
+          const { item, is_playing, progress_ms } = playback;
+          trackTitle.textContent = item.name;
+          trackSubtitle.textContent = `${item.artists.map(a => a.name).join(', ')} • ${item.album.name}`;
+          durationMs = item.duration_ms;
+          progressMs = progress_ms || 0;
+          updateProgressUi();
+          setPlayingState(!!is_playing);
+          if (is_playing) {
+            startProgressTimer();
+          } else {
+            stopProgressTimer();
+          }
+          const albumImage = item.album.images?.[0]?.url;
+          if (albumImage) {
+            await setAlbumArt(albumImage);
+          }
+        } catch (err) {
+          console.error(err);
+          setStatus('Unable to fetch playback state');
+        }
+      };
+
+      const loadPlaylists = async () => {
+        playlistGrid.innerHTML = '';
+        playlistSubtitle.textContent = 'Loading your playlists…';
+        try {
+          const data = await apiRequest('me/playlists?limit=12');
+          if (!data || !data.items?.length) {
+            playlistSubtitle.textContent = "We couldn't find any playlists yet.";
+            return;
+          }
+          playlistSubtitle.textContent = `${data.items.length} playlists ready.`;
+          data.items.forEach(playlist => {
+            const card = document.createElement('article');
+            card.className = 'playlist-card';
+            card.innerHTML = `
+              <img src="${playlist.images?.[0]?.url ?? 'https://placehold.co/400x400/1ed760/ffffff?text=Playlist'}" alt="${playlist.name}" />
+              <div>
+                <h3>${playlist.name}</h3>
+                <p>${playlist.tracks.total} tracks</p>
+              </div>`;
+            card.onclick = () => showPlaylistTracks(playlist);
+            playlistGrid.appendChild(card);
+          });
+        } catch (err) {
+          console.error(err);
+          playlistSubtitle.textContent = 'Unable to load playlists right now.';
+        }
+      };
+
+      const showPlaylistTracks = async playlist => {
+        playlistSubtitle.textContent = `Exploring ${playlist.name}`;
+        trackList.hidden = false;
+        trackListTitle.textContent = playlist.name;
+        trackItems.innerHTML = '';
+        try {
+          const data = await apiRequest(`playlists/${playlist.id}/tracks?limit=25`);
+          if (!data || !data.items?.length) {
+            trackItems.innerHTML = '<p style="color: var(--text-secondary);">No tracks to display.</p>';
+            return;
+          }
+          data.items.forEach((entry, index) => {
+            const track = entry.track;
+            if (!track) return;
+            const el = document.createElement('button');
+            el.className = 'track-item';
+            el.type = 'button';
+            el.innerHTML = `
+              <span>${index + 1}</span>
+              <div>
+                <strong>${track.name}</strong>
+                <div>${track.artists.map(a => a.name).join(', ')}</div>
+              </div>
+              <span>${msToTime(track.duration_ms)}</span>`;
+            el.onclick = () => playSelectedTrack(track, playlist);
+            trackItems.appendChild(el);
+          });
+        } catch (err) {
+          console.error(err);
+          trackItems.innerHTML = '<p style="color: var(--text-secondary);">Unable to load tracks.</p>';
+        }
+      };
+
+      const playSelectedTrack = async (track, playlist) => {
+        if (!deviceId) {
+          setStatus('Player not ready yet');
+          return;
+        }
+        try {
+          await startPlayback(deviceId, {
+            context_uri: playlist.uri,
+            offset: { uri: track.uri }
+          });
+          setStatus(`Playing ${track.name}`);
+          await refreshNowPlaying();
+        } catch (err) {
+          console.error(err);
+          setStatus('Unable to start track');
+        }
+      };
+
+      const toggleDrawer = show => {
+        if (show) {
+          playlistDrawer.removeAttribute('hidden');
+        } else {
+          playlistDrawer.setAttribute('hidden', '');
+        }
+        playlistToggle.setAttribute('aria-expanded', show.toString());
+      };
+
+      playlistToggle.addEventListener('click', () => toggleDrawer(playlistDrawer.hasAttribute('hidden')));
+      closeDrawer.addEventListener('click', () => toggleDrawer(false));
+
+      loginBtn.onclick = async () => {
+        await ensureAuth();
+        setStatus('Authenticated. Initializing…');
+      };
+
+      shuffleBtn.onclick = async () => {
+        const current = shuffleBtn.getAttribute('aria-pressed') === 'true';
+        try {
+          await apiRequest(`me/player/shuffle?state=${current ? 'false' : 'true'}${deviceId ? `&device_id=${encodeURIComponent(deviceId)}` : ''}`, {
+            method: 'PUT'
+          });
+          shuffleBtn.setAttribute('aria-pressed', (!current).toString());
+          shuffleBtn.classList.toggle('btn-primary', !current);
+          setStatus(`Shuffle ${!current ? 'enabled' : 'disabled'}`);
+        } catch (err) {
+          console.error(err);
+          setStatus('Unable to toggle shuffle');
+        }
+      };
+
+      repeatBtn.onclick = async () => {
+        const cycle = ['off', 'context', 'track'];
+        const currentState = repeatBtn.dataset.state || 'off';
+        const nextState = cycle[(cycle.indexOf(currentState) + 1) % cycle.length];
+        try {
+          await apiRequest(`me/player/repeat?state=${nextState}${deviceId ? `&device_id=${encodeURIComponent(deviceId)}` : ''}`, {
+            method: 'PUT'
+          });
+          repeatBtn.dataset.state = nextState;
+          repeatBtn.setAttribute('aria-pressed', (nextState !== 'off').toString());
+          repeatBtn.classList.toggle('btn-primary', nextState !== 'off');
+          setStatus(`Repeat set to ${nextState}`);
+        } catch (err) {
+          console.error(err);
+          setStatus('Unable to toggle repeat');
+        }
+      };
+
+      prevBtn.onclick = async () => {
+        try {
+          await apiRequest('me/player/previous', { method: 'POST' });
+          setStatus('Previous track');
+          await refreshNowPlaying();
+        } catch (err) {
+          console.error(err);
+          setStatus('Unable to go to previous track');
+        }
+      };
+
+      nextBtn.onclick = async () => {
+        try {
+          await apiRequest('me/player/next', { method: 'POST' });
+          setStatus('Next track');
+          await refreshNowPlaying();
+        } catch (err) {
+          console.error(err);
+          setStatus('Unable to skip track');
+        }
+      };
+
+      volumeRange.addEventListener('input', async () => {
+        const volumePercent = Number(volumeRange.value);
+        try {
+          await apiRequest(`me/player/volume?volume_percent=${volumePercent}${deviceId ? `&device_id=${encodeURIComponent(deviceId)}` : ''}`, {
+            method: 'PUT'
+          });
+          setStatus(`Volume set to ${volumePercent}%`);
+        } catch (err) {
+          console.error(err);
+          setStatus('Unable to adjust volume');
+        }
+      });
+
+      playBtn.onclick = async () => {
+        if (!deviceId) {
+          setStatus('Device not ready yet');
+          return;
+        }
+        try {
+          await startPlayback(deviceId, { uris: ['spotify:track:3n3Ppam7vgaVa1iaRUc9Lp'] });
+          setStatus('Starting playback');
+          await refreshNowPlaying();
+        } catch (err) {
+          console.error(err);
+          setStatus('Unable to start playback');
+        }
+      };
+
+      pauseBtn.onclick = async () => {
+        if (!playerInstance) return;
+        try {
+          pause(playerInstance);
+          setPlayingState(false);
+          stopProgressTimer();
+          setStatus('Paused');
+          await refreshNowPlaying();
+        } catch (err) {
+          console.error(err);
+          setStatus('Unable to pause');
+        }
+      };
+
+      resumeBtn.onclick = async () => {
+        playBtn.click();
+      };
+
+      const onPlayerReady = ({ deviceId: readyDeviceId, player }) => {
+        deviceId = readyDeviceId;
+        playerInstance = player;
+        setStatus(`Device ready: ${deviceId}`);
+        playBtn.disabled = false;
+        pauseBtn.disabled = false;
+        volumeRange.disabled = false;
+        toggleDrawer(true);
+        loadPlaylists();
+        refreshNowPlaying();
+      };
 
       window.onSpotifyWebPlaybackSDKReady = async () => {
         const token = getAccessTokenSync();
         if (!token) {
-          status.textContent = 'Click “Log in with Spotify” first.';
+          setStatus('Log in with Spotify to begin');
           return;
         }
-        status.textContent = 'Initializing player…';
-
-        const { deviceId, player } = await initPlayer(() => getAccessTokenSync());
-        status.textContent = `Device ready: ${deviceId}`;
-
-        playBtn.disabled = false;
-        pauseBtn.disabled = false;
-
-        // Must be triggered by a user gesture
-        playBtn.onclick = () =>
-          startPlayback(deviceId, { uris: ['spotify:track:3n3Ppam7vgaVa1iaRUc9Lp'] }); // example
-        pauseBtn.onclick = () => pause(player);
+        setStatus('Initializing player…');
+        try {
+          const { deviceId, player } = await initPlayer(() => getAccessTokenSync());
+          onPlayerReady({ deviceId, player });
+        } catch (err) {
+          console.error(err);
+          setStatus('Unable to initialize player');
+        }
       };
+
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') {
+          refreshNowPlaying();
+        }
+      });
+
+      toggleDrawer(false);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- overhaul the landing page into a two-pane experience with an animated vinyl player and dedicated control panel
- surface expanded Spotify controls for shuffle, repeat, queue navigation, and device volume management
- introduce playlist browser drawer with track previews and contextual playback launch from user collections

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ef8b9355d4832b8bbe2a523f0fe659